### PR TITLE
Fix bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   ],
   "devDependencies": {
     "jquery": "~2.1.3",
-    "startbootstrap-sb-admin-2": "git@github.com:BlackrockDigital/startbootstrap-sb-admin-2#v3.3.7+1",
+    "startbootstrap-sb-admin-2": "BlackrockDigital/startbootstrap-sb-admin-2#v3.3.7+1",
     "rxjs": "~4.1.0",
     "moment": "~2.17.0"
   },


### PR DESCRIPTION
Make bower not require GitHub account.
See: BlackrockDigital/startbootstrap-sb-admin-2#130